### PR TITLE
Bugfixes to return 503 and pass smoke tests

### DIFF
--- a/error.html
+++ b/error.html
@@ -1,1 +1,10 @@
-Sorry
+<!DOCTYPE html>
+<html> 
+	<head>
+		<title>503 Service Unavailable</title>
+	</head>
+	<body> 
+		<!-- CF: 404 -->
+		Sorry - Service is temporarily unavailable, please try again later
+	</body> 
+</html> 

--- a/nginx.conf
+++ b/nginx.conf
@@ -31,8 +31,14 @@ http {
     root <%= ENV["APP_ROOT"] %>/public;
 
     location / {
-        rewrite ^(.*)$ /error.html break;
-        return 503;
+      root <%= ENV["APP_ROOT"] %>/public;
+      return 503;
     }
+    error_page 503 @maintenance;
+    location @maintenance {
+      root <%= ENV["APP_ROOT"] %>/public;
+      rewrite ^(.*)$ /error.html break;
+    }
+
   }
 }


### PR DESCRIPTION
Bugfix: make nginx return really return a 503 (old version used status code 200)
Bugfix: add "404" text to pass cloud foundry smoke tests (workaround)